### PR TITLE
Fix incorrect detection of LIFX white bulbs

### DIFF
--- a/examples/pulse.py
+++ b/examples/pulse.py
@@ -29,18 +29,18 @@ discover = loop.create_datagram_endpoint(
 loop.create_task(discover)
 
 # Probe
-sleep = loop.create_task(asyncio.sleep(1))
+sleep = loop.create_task(asyncio.sleep(3))
 loop.run_until_complete(sleep)
 
 # Run effect
 devices = list(mybulbs.bulbs.values())
-effect = aiolifx_effects.EffectColorloop(period=1)
+effect = aiolifx_effects.EffectPulse(power_on=True, mode="blink", cycles=3)
 loop.create_task(conductor.start(effect, devices))
 
 # Stop effect in a while
 stop = conductor.stop(devices)
-loop.call_later(10, lambda: loop.create_task(stop))
+loop.call_later(3, lambda: loop.create_task(stop))
 
 # Wait for completion
-sleep = loop.create_task(asyncio.sleep(12))
+sleep = loop.create_task(asyncio.sleep(4))
 loop.run_until_complete(sleep)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 setup(
     name='aiolifx_effects',
     packages=['aiolifx_effects'],
-    version='0.3.0',
+    version='0.3.1',
     install_requires=['aiolifx>=0.8.6'],
     description='aiolifx light effects',
     author='Anders Melchiorsen',


### PR DESCRIPTION
First, by fixing the actual comparison made against the capabilities map and then by ensuring each participating device has a value for product type.

Required to resolve https://github.com/home-assistant/core/issues/83719

Signed-off-by: Avi Miller <me@dje.li>